### PR TITLE
URI, URL and fallbacks

### DIFF
--- a/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
+++ b/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
@@ -9,19 +9,22 @@ import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
 
+import java.net.URI;
+
 import static org.junit.Assert.assertEquals;
 
 public class LocationServiceTest extends JUnitSuite {
     @Test
-    public void return_None_when_running_in_development_mode() throws Exception {
+    public void return_the_fallback_when_running_in_development_mode() throws Exception {
         ActorSystem system = ActorSystem.create("MySystem");
 
-        ConnectionContext cc = ConnectionContext.create(system);
+        URI fallback = new URI("/fallback");
         LocationCache cache = new LocationCache();
+        ConnectionContext cc = ConnectionContext.create(system);
         Timeout timeout = new Timeout(Duration.create(5, "seconds"));
         assertEquals(
-            Await.result(LocationService.getInstance().lookupWithContext("/whatever", cc, cache), timeout.duration()),
-            Option.none()
+            Await.result(LocationService.getInstance().lookupWithContext("/whatever", fallback, cache, cc), timeout.duration()),
+            Option.some(fallback)
         );
     }
 }

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
@@ -34,18 +34,18 @@ public class LocationService {
     }
 
     /**
-     * A convenience function for [[createLookupPayload]] where the payload url is created when this bundle component
-     * is running in the context of ConductR. If it is not then a fallbackUrl is returned.
+     * A convenience function where the payload url is created when this bundle component
+     * is running in the context of ConductR. If it is not then a fallback is returned.
      * @param serviceName The name of the service
-     * @param fallbackUrl The url to use when not running with ConductR
+     * @param fallback The url to use when not running with ConductR
      * @throws MalformedURLException
      */
-    public static String getLookupUrl(String serviceName, String fallbackUrl) throws MalformedURLException {
+    public static URL getLookupUrl(String serviceName, URL fallback) throws MalformedURLException {
         HttpPayload payload = createLookupPayload(serviceName);
         if (payload == null) {
-            return fallbackUrl;
+            return fallback;
         } else {
-            return payload.getUrl().toString();
+            return payload.getUrl();
         }
     }
 

--- a/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/LocationServiceSpec.scala
+++ b/conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/LocationServiceSpec.scala
@@ -1,5 +1,7 @@
 package com.typesafe.conductr.bundlelib
 
+import java.net.URL
+
 import com.typesafe.conductr.UnitTest
 
 class LocationServiceSpec extends UnitTest {
@@ -10,7 +12,8 @@ class LocationServiceSpec extends UnitTest {
     }
 
     "return the fallback when running in development mode" in {
-      LocationService.getLookupUrl("/whatever", "http://127.0.0.1/whatever") shouldBe "http://127.0.0.1/whatever"
+      val fallback = new URL("http://127.0.0.1/whatever")
+      LocationService.getLookupUrl("/whatever", fallback) shouldBe fallback
     }
   }
 }

--- a/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
+++ b/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
@@ -8,18 +8,21 @@ import play.libs.F;
 import play.libs.HttpExecution;
 import scala.concurrent.duration.Duration;
 
+import java.net.URI;
+
 import static org.junit.Assert.assertEquals;
 
 public class LocationServiceTest extends JUnitSuite {
     @Test
-    public void return_None_when_running_in_development_mode() throws Exception {
-        ConnectionContext cc = ConnectionContext.create(HttpExecution.defaultContext());
+    public void return_fallback_when_running_in_development_mode() throws Exception {
+        URI fallback = new URI("/fallback");
         LocationCache cache = new LocationCache();
+        ConnectionContext cc = ConnectionContext.create(HttpExecution.defaultContext());
         Timeout timeout = new Timeout(Duration.create(5, "seconds"));
 
         assertEquals(
-            LocationService.getInstance().lookupWithContext("/whatever", cc, cache).get(timeout.duration().toMillis()),
-            F.None()
+            LocationService.getInstance().lookupWithContext("/whatever", fallback, cache, cc).get(timeout.duration().toMillis()),
+            F.Some(fallback)
         );
     }
 }

--- a/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
+++ b/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
@@ -8,18 +8,21 @@ import play.libs.F;
 import play.libs.HttpExecution;
 import scala.concurrent.duration.Duration;
 
+import java.net.URI;
+
 import static org.junit.Assert.assertEquals;
 
 public class LocationServiceTest extends JUnitSuite {
     @Test
     public void return_None_when_running_in_development_mode() throws Exception {
-        ConnectionContext cc = ConnectionContext.create(HttpExecution.defaultContext());
+        URI fallback = new URI("");
         LocationCache cache = new LocationCache();
+        ConnectionContext cc = ConnectionContext.create(HttpExecution.defaultContext());
         Timeout timeout = new Timeout(Duration.create(5, "seconds"));
 
         assertEquals(
-            LocationService.getInstance().lookupWithContext("/whatever", cc, cache).get(timeout.duration().toMillis()),
-            F.None()
+            LocationService.getInstance().lookupWithContext("/whatever", fallback, cache, cc).get(timeout.duration().toMillis()),
+            F.Some(fallback)
         );
     }
 }

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.play
 
-import java.net.{ InetSocketAddress, URL }
+import java.net.{ URI => JavaURI, InetSocketAddress }
 
 import akka.actor._
 import akka.http.scaladsl.Http
@@ -10,7 +10,7 @@ import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorFlowMaterializer
 import akka.testkit.TestProbe
 import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
-import com.typesafe.conductr.bundlelib.scala.LocationCache
+import com.typesafe.conductr.bundlelib.scala.{ URL, URI, LocationCache }
 import com.typesafe.conductr.{ AkkaUnitTest, _ }
 
 import scala.concurrent.Await
@@ -23,26 +23,16 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
   "The LocationService functionality in the library" should {
 
     "be able to look up a named service" in {
-      val serviceUri = "http://service_interface:4711/known"
+      val serviceUri = URI("http://service_interface:4711/known")
       withServerWithKnownService(serviceUri) {
-
-        val service = LocationService.lookup("/known")
-        Await.result(service, timeout.duration) shouldBe Some(serviceUri)
-      }
-    }
-
-    "be able to look up a named service using a cache" in {
-      val serviceUri = "http://service_interface:4711/known"
-      withServerWithKnownService(serviceUri) {
-
         val cache = LocationCache()
-        val service = LocationService.lookup("/known", cache)
+        val service = LocationService.lookup("/known", URI(""), cache)
         Await.result(service, timeout.duration) shouldBe Some(serviceUri)
       }
     }
   }
 
-  def withServerWithKnownService(serviceUrl: String, maxAge: Option[Int] = None)(thunk: => Unit): Unit = {
+  def withServerWithKnownService(serviceUri: JavaURI, maxAge: Option[Int] = None)(thunk: => Unit): Unit = {
     import system.dispatcher
     implicit val materializer = ActorFlowMaterializer.create(system)
 
@@ -54,7 +44,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
           complete {
             serviceName match {
               case "known" =>
-                val headers = Location(serviceUrl) :: (maxAge match {
+                val headers = Location(serviceUri.toString) :: (maxAge match {
                   case Some(maxAgeSecs) =>
                     `Cache-Control`(
                       CacheDirectives.`private`(Location.name),
@@ -62,7 +52,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
                   case None =>
                     Nil
                 })
-                HttpResponse(StatusCodes.TemporaryRedirect, headers, HttpEntity(s"Located at $serviceUrl"))
+                HttpResponse(StatusCodes.TemporaryRedirect, headers, HttpEntity(s"Located at $serviceUri"))
               case _ =>
                 HttpResponse(StatusCodes.NotFound)
             }
@@ -70,7 +60,7 @@ class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEn
         }
       }
 
-    val url = new URL(Env.serviceLocator.get)
+    val url = URL(Env.serviceLocator.get)
     val server = Http(system).bindAndHandle(handler, url.getHost, url.getPort)
 
     try {

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationCache.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationCache.scala
@@ -1,5 +1,6 @@
 package com.typesafe.conductr.bundlelib.scala
 
+import java.net.{ URI => JavaURI }
 import java.util.{ TimerTask, Timer }
 
 import scala.collection.concurrent.TrieMap
@@ -12,8 +13,8 @@ import scala.util.Success
  * A structure that describes what we require from a cache.
  */
 trait CacheLike {
-  def getOrElseUpdate(serviceName: String)(op: => Future[Option[(String, Option[FiniteDuration])]]): Future[Option[String]]
-  def remove(serviceName: String): Option[Future[Option[String]]]
+  def getOrElseUpdate(serviceName: String)(op: => Future[Option[(JavaURI, Option[FiniteDuration])]]): Future[Option[JavaURI]]
+  def remove(serviceName: String): Option[Future[Option[JavaURI]]]
 }
 
 object LocationCache {
@@ -33,12 +34,12 @@ object LocationCache {
  */
 class LocationCache extends CacheLike {
 
-  private val cache = TrieMap.empty[String, Future[Option[String]]]
+  private val cache = TrieMap.empty[String, Future[Option[JavaURI]]]
 
   val reaperTimer = new Timer()
 
-  override def getOrElseUpdate(serviceName: String)(op: => Future[Option[(String, Option[FiniteDuration])]]): Future[Option[String]] = {
-    def dualOp: Future[Option[String]] = {
+  override def getOrElseUpdate(serviceName: String)(op: => Future[Option[(JavaURI, Option[FiniteDuration])]]): Future[Option[JavaURI]] = {
+    def dualOp: Future[Option[JavaURI]] = {
       val locationAndMaxAge = op
 
       import Implicits.global
@@ -61,6 +62,6 @@ class LocationCache extends CacheLike {
     cache.getOrElseUpdate(serviceName, dualOp)
   }
 
-  override def remove(serviceName: String): Option[Future[Option[String]]] =
+  override def remove(serviceName: String): Option[Future[Option[JavaURI]]] =
     cache.remove(serviceName)
 }

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ResourceOps.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/ResourceOps.scala
@@ -1,0 +1,19 @@
+package com.typesafe.conductr.bundlelib.scala
+
+import java.net.{ URI => JavaURI, URL => JavaURL }
+
+/**
+ * Conveniently build a URI
+ */
+object URI {
+  def apply(s: String): JavaURI =
+    new JavaURI(s)
+}
+
+/**
+ * Conveniently build a URL
+ */
+object URL {
+  def apply(s: String): JavaURL =
+    new JavaURL(s)
+}

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationCacheSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationCacheSpec.scala
@@ -11,34 +11,34 @@ class LocationCacheSpec extends AkkaUnitTest {
     "invoke the op when there is no entry initially, return the cached entry when not, and expire" in {
       var updates = 0
       val cache = LocationCache()
-      def getFromCache(serviceName: String): Future[Option[String]] =
+      def getFromCache(serviceName: String): Future[Option[java.net.URI]] =
         cache.getOrElseUpdate(serviceName) {
           if (serviceName == "/someservice") {
             updates += 1
-            Future.successful(Some("/somelocation" -> Some(100.millis)))
+            Future.successful(Some(URI("/somelocation") -> Some(100.millis)))
           } else
             throw new IllegalStateException(s"Some bad service: $serviceName")
         }
 
       val location1 = getFromCache("/someservice")
-      Await.result(location1, timeout.duration) shouldBe Some("/somelocation")
+      Await.result(location1, timeout.duration) shouldBe Some(URI("/somelocation"))
       updates shouldBe 1
 
       // Shouldn't invoke the op for this - it should just return the cache value
       val location2 = getFromCache("/someservice")
-      Await.result(location2, timeout.duration) shouldBe Some("/somelocation")
+      Await.result(location2, timeout.duration) shouldBe Some(URI("/somelocation"))
       updates shouldBe 1
 
       // Let the cache expire
       Thread.sleep(200)
 
       val location3 = getFromCache("/someservice")
-      Await.result(location3, timeout.duration) shouldBe Some("/somelocation")
+      Await.result(location3, timeout.duration) shouldBe Some(URI("/somelocation"))
       updates shouldBe 2
 
       cache.remove("/someservice") shouldBe Some(location3)
       val location4 = getFromCache("/someservice")
-      Await.result(location4, timeout.duration) shouldBe Some("/somelocation")
+      Await.result(location4, timeout.duration) shouldBe Some(URI("/somelocation"))
       updates shouldBe 3
     }
   }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
@@ -9,12 +9,15 @@ class LocationServiceSpec extends AkkaUnitTest {
   import Implicits.global
 
   "The LocationService functionality in the library" should {
-    "return None when running in development mode" in {
-      Await.result(LocationService.lookup("/whatever"), timeout.duration) shouldBe None
+    "return the fallback uri when running in development mode" in {
+      val fallback = URI("/fallback")
+      val cache = LocationCache()
+      Await.result(LocationService.lookup("/whatever", fallback, cache), timeout.duration) shouldBe Some(fallback)
     }
 
     "return the fallback url when running in development mode" in {
-      LocationService.getLookupUrl("/whatever", "http://127.0.0.1/whatever") shouldBe "http://127.0.0.1/whatever"
+      val fallback = URL("http://127.0.0.1/whatever")
+      LocationService.getLookupUrl("/whatever", fallback) shouldBe fallback
     }
   }
 }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpecWithEnv.scala
@@ -5,9 +5,8 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorFlowMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr._
 import com.typesafe.conductr.AkkaUnitTest
-import java.net.{ InetSocketAddress, URL }
+import java.net.InetSocketAddress
 import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits
 
 import scala.concurrent.Await
@@ -37,7 +36,7 @@ class StatusServiceSpecWithEnv extends AkkaUnitTest("StatusServiceSpecWithEnv", 
           }
         }
 
-      val url = new URL(Env.conductRStatus.get)
+      val url = URL(Env.conductRStatus.get)
       val server = Http(system).bindAndHandle(handler, url.getHost, url.getPort)
 
       try {


### PR DESCRIPTION
The JDK URI and URL types are now used instead of strings in order to reduce type conversions. In addition a fallback URI is now supplied to the service locator function in order to reduce the amount of boilerplate for a user of the API. A new ResourceOps files provides two convenience constructors for the JDK URI and URL types also - in order to keep the noise down.

Finally, the no-cache flavour of the locator lookup function was removed as the use of a cache is encouraged strongly.