### PR TITLE
ConductR 1.1 update - consider `BUNDLE_SYSTEM` and `BUNDLE_SYSTEM_VERSION` when setting up Akka cluster

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,15 @@
 
 This project provides a number of libraries to facilitate [ConductR](http://typesafe.com/products/conductr)'s status service and its service lookup service. Note that usage of the libraries in your code is entirely benign when used outside of the context of ConductR i.e. you will find that your applications and services will continue to function normally when used without ConductR. We have also designed the libraries to be a convenience to ConductR's REST and environment variable based APIs, and to have a very low impact on your code.
 
-The libraries are structured as follows:
+If using ConductR 1.1 and above, the libraries are structured as follows:
+
+* `"com.typesafe.conductr" %  "conductr-bundle-lib"        % "1.1.0"`
+* `"com.typesafe.conductr" %% "scala-conductr-bundle-lib"  % "1.1.0"`
+* `"com.typesafe.conductr" %% "akka23-conductr-bundle-lib" % "1.1.0"`
+* `"com.typesafe.conductr" %% "play23-conductr-bundle-lib" % "1.1.0"`
+* `"com.typesafe.conductr" %% "play24-conductr-bundle-lib" % "1.1.0"`
+
+If using ConductR 1.0.*, the libraries are structured as follows:
 
 * `"com.typesafe.conductr" %  "conductr-bundle-lib"        % "1.0.1"`
 * `"com.typesafe.conductr" %% "scala-conductr-bundle-lib"  % "1.0.1"`

--- a/akka23-conductr-bundle-lib/build.sbt
+++ b/akka23-conductr-bundle-lib/build.sbt
@@ -18,7 +18,8 @@ def groupByFirst(tests: Seq[TestDefinition]) =
       case ("WithEnvForHost", t) =>
         new Group("WithEnvForHost", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_HOST_IP" -> "10.0.1.10",
-          "BUNDLE_SYSTEM" -> "some-system-1.0.0",
+          "BUNDLE_SYSTEM" -> "some-system",
+          "BUNDLE_SYSTEM_VERSION" -> "v1",
           "AKKA_REMOTE_PROTOCOL" -> "tcp",
           "AKKA_REMOTE_HOST_PORT" -> "10000",
           "AKKA_REMOTE_OTHER_PROTOCOLS" -> "",
@@ -27,7 +28,8 @@ def groupByFirst(tests: Seq[TestDefinition]) =
       case ("WithEnvForOneOther", t) =>
         new Group("WithEnvForOneOther", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_HOST_IP" -> "10.0.1.10",
-          "BUNDLE_SYSTEM" -> "some-system-1.0.0",
+          "BUNDLE_SYSTEM" -> "some-system",
+          "BUNDLE_SYSTEM_VERSION" -> "v1",
           "AKKA_REMOTE_PROTOCOL" -> "tcp",
           "AKKA_REMOTE_HOST_PORT" -> "10000",
           "AKKA_REMOTE_OTHER_PROTOCOLS" -> "udp",
@@ -36,7 +38,8 @@ def groupByFirst(tests: Seq[TestDefinition]) =
       case ("WithEnvForOthers", t) =>
         new Group("WithEnvForOthers", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_HOST_IP" -> "10.0.1.10",
-          "BUNDLE_SYSTEM" -> "some-system-1.0.0",
+          "BUNDLE_SYSTEM" -> "some-system",
+          "BUNDLE_SYSTEM_VERSION" -> "v1",
           "AKKA_REMOTE_PROTOCOL" -> "tcp",
           "AKKA_REMOTE_HOST_PORT" -> "10000",
           "AKKA_REMOTE_OTHER_PROTOCOLS" -> "udp:tcp",

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForHost.scala
@@ -8,7 +8,7 @@ class EnvSpecWithEnvForHost extends AkkaUnitTest("EnvSpecWithEnvForHost", "akka.
 
   "The Env functionality in the library" should {
     "return seed properties when running with no other seed nodes" in {
-      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.tcp://some-system-1_0_0@10.0.1.10:10000"
+      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.tcp://some-system-v1@10.0.1.10:10000"
       config.getString("akka.remote.netty.tcp.hostname") shouldBe "10.0.1.10"
       config.getInt("akka.remote.netty.tcp.port") shouldBe 10000
     }

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOneOther.scala
@@ -9,7 +9,7 @@ class EnvSpecWithEnvForOneOther extends AkkaUnitTest("EnvSpecWithEnvForOthers", 
 
   "The Env functionality in the library" should {
     "return seed properties when running with one other seed node" in {
-      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.udp://some-system-1_0_0@10.0.1.11:10001"
+      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.udp://some-system-v1@10.0.1.11:10001"
       intercept[Missing](config.getString("akka.cluster.seed-nodes.1"))
     }
   }

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/EnvSpecWithEnvForOthers.scala
@@ -9,8 +9,8 @@ class EnvSpecWithEnvForOthers extends AkkaUnitTest("EnvSpecWithEnvForOthers", "a
 
   "The Env functionality in the library" should {
     "return seed properties when running with other seed nodes" in {
-      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.udp://some-system-1_0_0@10.0.1.11:10001"
-      config.getString("akka.cluster.seed-nodes.1") shouldBe "akka.tcp://some-system-1_0_0@10.0.1.12:10000"
+      config.getString("akka.cluster.seed-nodes.0") shouldBe "akka.udp://some-system-v1@10.0.1.11:10001"
+      config.getString("akka.cluster.seed-nodes.1") shouldBe "akka.tcp://some-system-v1@10.0.1.12:10000"
       intercept[Missing](config.getString("akka.cluster.seed-nodes.2"))
     }
   }

--- a/play23-conductr-bundle-lib/build.sbt
+++ b/play23-conductr-bundle-lib/build.sbt
@@ -20,7 +20,8 @@ def groupByFirst(tests: Seq[TestDefinition]) =
       case ("WithEnv", t) =>
         new Group("WithEnv", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_ID" -> "0BADF00DDEADBEEF",
-          "BUNDLE_SYSTEM" -> "somesys-1.0.0",
+          "BUNDLE_SYSTEM" -> "somesys",
+          "BUNDLE_SYSTEM_VERSION" -> "v1",
           "CONDUCTR_STATUS" -> "http://127.0.0.1:40007",
           "SERVICE_LOCATOR" -> "http://127.0.0.1:40008/services",
           "WEB_BIND_IP" -> "127.0.0.1",

--- a/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
+++ b/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
@@ -19,8 +19,15 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
     val httpAddress = sys.env.get(s"${webName}_BIND_IP").toList.map("http.address" -> _)
     val httpPort = sys.env.get(s"${webName}_BIND_PORT").toList.map("http.port" -> _)
 
-    val playActorSystem = sys.env.get("BUNDLE_SYSTEM").toList.map("play.akka.actor-system" -> AkkaEnv.mkSystem(_))
-
     ConfigFactory.parseMap((httpAddress ++ httpPort ++ playActorSystem).toMap.asJava)
   }
+
+  private def playActorSystem: List[(String, String)] =
+    (for {
+      bundleSystem <- sys.env.get("BUNDLE_SYSTEM")
+      bundleSystemVersion <- sys.env.get("BUNDLE_SYSTEM_VERSION")
+    } yield {
+      val actorSystemName = s"${AkkaEnv.mkSystemId(bundleSystem)}-${AkkaEnv.mkSystemId(bundleSystemVersion)}"
+      "play.akka.actor-system" -> actorSystemName
+    }).toList
 }

--- a/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
+++ b/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
@@ -10,7 +10,7 @@ class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost", "akka.logleve
     "initialize the env like expected" in {
       config.getString("http.address") shouldBe "127.0.0.1"
       config.getString("http.port") shouldBe "9000"
-      config.getString("play.akka.actor-system") shouldBe "somesys-1_0_0"
+      config.getString("play.akka.actor-system") shouldBe "somesys-v1"
     }
   }
 }

--- a/play24-conductr-bundle-lib/build.sbt
+++ b/play24-conductr-bundle-lib/build.sbt
@@ -20,7 +20,8 @@ def groupByFirst(tests: Seq[TestDefinition]) =
       case ("WithEnv", t) =>
         new Group("WithEnv", t, SubProcess(ForkOptions(envVars = Map(
           "BUNDLE_ID" -> "0BADF00DDEADBEEF",
-          "BUNDLE_SYSTEM" -> "somesys-1.0.0",
+          "BUNDLE_SYSTEM" -> "somesys",
+          "BUNDLE_SYSTEM_VERSION" -> "v1",
           "CONDUCTR_STATUS" -> "http://127.0.0.1:30007",
           "SERVICE_LOCATOR" -> "http://127.0.0.1:30008/services",
           "WEB_BIND_IP" -> "127.0.0.1",

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/Env.scala
@@ -19,8 +19,15 @@ object Env extends com.typesafe.conductr.bundlelib.scala.Env {
     val httpAddress = sys.env.get(s"${webName}_BIND_IP").toList.map("http.address" -> _)
     val httpPort = sys.env.get(s"${webName}_BIND_PORT").toList.map("http.port" -> _)
 
-    val playActorSystem = sys.env.get("BUNDLE_SYSTEM").toList.map("play.akka.actor-system" -> AkkaEnv.mkSystem(_))
-
     ConfigFactory.parseMap((httpAddress ++ httpPort ++ playActorSystem).toMap.asJava)
   }
+
+  private def playActorSystem: List[(String, String)] =
+    (for {
+      bundleSystem <- sys.env.get("BUNDLE_SYSTEM")
+      bundleSystemVersion <- sys.env.get("BUNDLE_SYSTEM_VERSION")
+    } yield {
+      val actorSystemName = s"${AkkaEnv.mkSystemId(bundleSystem)}-${AkkaEnv.mkSystemId(bundleSystemVersion)}"
+      "play.akka.actor-system" -> actorSystemName
+    }).toList
 }

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/EnvSpecWithEnv.scala
@@ -10,7 +10,7 @@ class EnvSpecWithEnv extends AkkaUnitTest("EnvSpecWithEnvForHost", "akka.logleve
     "initialize the env like expected" in {
       config.getString("http.address") shouldBe "127.0.0.1"
       config.getString("http.port") shouldBe "9000"
-      config.getString("play.akka.actor-system") shouldBe "somesys-1_0_0"
+      config.getString("play.akka.actor-system") shouldBe "somesys-v1"
     }
   }
 }


### PR DESCRIPTION
As of ConductR 1.1 the system version value is now extracted from `BUNDLE_SYSTEM` environment variable, and made available to running applications as a separate `BUNDLE_SYSTEM_VERSION` environment variable.

Ensure the Akka cluster name takes into account `BUNDLE_SYSTEM` and `BUNDLE_SYSTEM_VERSION` when starting Akka and Play based applications.