### PR TITLE
Base structure for client library

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ If the service you require is not HTTP based then you may use the `LocationServi
 // is needed as "service" is returned as a Future.
 // For convenience, we provide a global ConnectionContext
 // that may be imported.
-import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits.global
+import com.typesafe.conductr.scala.ConnectionContext.Implicits.global
 
 val locationCache = LocationCache()
 
@@ -274,7 +274,7 @@ and there is also another:
 Please read the section on `conductr-bundle-lib` and then `scala-conductr-bundle-lib` for an introduction to these services. The `Env` one is discussed in the section below. Other than the `import`s for the types, the only difference in terms of API are usage is how a `ConnectionContext` is established. A `ConnectionContext` for Play requires an `ExecutionContext` at a minimum. For convenience, we provide a default ConnectionContext using the default execution context. This may be imported e.g.:
 
 ```scala
-  import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits.defaultContext
+  import com.typesafe.conductr.play.ConnectionContext.Implicits.defaultContext
 ```
 
 There is also a lower level method where the `ExecutionContext` is passed in:

--- a/akka23-common/build.sbt
+++ b/akka23-common/build.sbt
@@ -1,0 +1,5 @@
+name := "akka23-common-conductr-lib"
+
+libraryDependencies ++= List(
+  Library.akka23Http
+)

--- a/akka23-common/src/main/scala/com/typesafe/conductr/akka/ConnectionHandler.scala
+++ b/akka23-common/src/main/scala/com/typesafe/conductr/akka/ConnectionHandler.scala
@@ -1,4 +1,4 @@
-package com.typesafe.conductr.bundlelib.akka
+package com.typesafe.conductr.akka
 
 import akka.actor._
 import akka.http.scaladsl.client.RequestBuilding.{ Get, Post, Put, Patch, Delete, Options, Head }
@@ -6,8 +6,8 @@ import akka.http.scaladsl.{ Http, HttpExt }
 import akka.http.scaladsl.model.headers.{ Host, `User-Agent` }
 import akka.stream.ActorMaterializer
 import akka.stream.scaladsl.{ Sink, Source }
-import com.typesafe.conductr.bundlelib.HttpPayload
-import com.typesafe.conductr.bundlelib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import com.typesafe.conductr.HttpPayload
+import com.typesafe.conductr.scala.{ AbstractConnectionContext, AbstractConnectionHandler }
 
 import scala.concurrent.Future
 
@@ -66,7 +66,7 @@ trait ImplicitConnectionContext { this: Actor =>
  * INTERNAL API
  * Handles the Akka-http requests and responses
  */
-private[bundlelib] class ConnectionHandler extends AbstractConnectionHandler {
+class ConnectionHandler extends AbstractConnectionHandler {
 
   override protected type CC = ConnectionContext
 

--- a/akka23-conductr-bundle-lib/build.sbt
+++ b/akka23-conductr-bundle-lib/build.sbt
@@ -4,7 +4,6 @@ name := "akka23-conductr-bundle-lib"
 
 libraryDependencies ++= List(
   Library.akka23Cluster,
-  Library.akka23Http,
   Library.akka23Testkit % "test",
   Library.scalaTest     % "test"
 )

--- a/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/LocationService.scala
+++ b/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/LocationService.scala
@@ -2,6 +2,7 @@ package com.typesafe.conductr.bundlelib.akka
 
 import java.net.URI
 
+import com.typesafe.conductr.akka._
 import com.typesafe.conductr.bundlelib.scala.{ CacheLike, AbstractLocationService }
 
 import akka.japi.{ Option => JOption }

--- a/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/StatusService.scala
+++ b/akka23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/akka/StatusService.scala
@@ -1,5 +1,6 @@
 package com.typesafe.conductr.bundlelib.akka
 
+import com.typesafe.conductr.akka._
 import com.typesafe.conductr.bundlelib.scala.AbstractStatusService
 
 import akka.japi.{ Option => JOption }

--- a/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
+++ b/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/LocationServiceTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
+import com.typesafe.conductr.akka.ConnectionContext;
 
 import java.net.URI;
 

--- a/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/StatusServiceTest.java
+++ b/akka23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/akka/StatusServiceTest.java
@@ -7,7 +7,7 @@ import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import scala.concurrent.Await;
 import scala.concurrent.duration.Duration;
-
+import com.typesafe.conductr.akka.ConnectionContext;
 import static org.junit.Assert.assertEquals;
 
 public class StatusServiceTest extends JUnitSuite {

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/LocationServiceSpecWithEnv.scala
@@ -11,7 +11,7 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
 import com.typesafe.conductr.bundlelib.scala.{ URL, URI, CacheLike, LocationCache }
 import com.typesafe.conductr.AkkaUnitTest
-
+import com.typesafe.conductr.akka._
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }
 

--- a/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/StatusServiceSpecWithEnv.scala
+++ b/akka23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/akka/StatusServiceSpecWithEnv.scala
@@ -7,9 +7,9 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.testkit.TestProbe
 import com.typesafe.conductr.{ AkkaUnitTest, _ }
-
-import scala.concurrent.Await
-import scala.util.{ Failure, Success }
+import com.typesafe.conductr.akka._
+import _root_.scala.concurrent.Await
+import _root_.scala.util.{ Failure, Success }
 
 class StatusServiceSpecWithEnv extends AkkaUnitTest("StatusServiceSpecWithEnv", "akka.loglevel = INFO") {
 

--- a/akka23-conductr-client-lib/build.sbt
+++ b/akka23-conductr-client-lib/build.sbt
@@ -1,0 +1,1 @@
+name := "akka23-conductr-client-lib"

--- a/build.sbt
+++ b/build.sbt
@@ -1,36 +1,97 @@
 lazy val root = project
   .in(file("."))
   .aggregate(
+    common,
     conductRBundleLib,
     scalaConductRBundleLib,
     akka23ConductRBundleLib,
     play23ConductRBundleLib,
     play24ConductRBundleLib)
 
+
+// Base
+lazy val common = project
+  .in(file("common"))
+  .dependsOn(testLib % "test->compile")
+
 lazy val conductRBundleLib = project
   .in(file("conductr-bundle-lib"))
+  .dependsOn(common)
   .dependsOn(testLib % "test->compile")
+
+
+// Scala
+lazy val scalaCommon = project
+  .in(file("scala-common"))
+  .dependsOn(common)
 
 lazy val scalaConductRBundleLib = project
   .in(file("scala-conductr-bundle-lib"))
   .dependsOn(conductRBundleLib)
+  .dependsOn(scalaCommon)
   .dependsOn(testLib % "test->compile")
+
+lazy val scalaConductRClientLib = project
+  .in(file("scala-conductr-client-lib"))
+  .dependsOn(scalaCommon)
+  .dependsOn(testLib % "test->compile")
+
+
+// Akka 2.3
+lazy val akka23Common = project
+  .in(file("akka23-common"))
+  .dependsOn(scalaCommon)
 
 lazy val akka23ConductRBundleLib = project
   .in(file("akka23-conductr-bundle-lib"))
   .dependsOn(scalaConductRBundleLib)
+  .dependsOn(akka23Common)
   .dependsOn(testLib % "test->compile")
+
+lazy val akka23ConductRClientLib = project
+  .in(file("akka23-conductr-client-lib"))
+  .dependsOn(scalaConductRClientLib)
+  .dependsOn(akka23Common)
+  .dependsOn(testLib % "test->compile")
+
+
+// Play 2.3
+lazy val play23Common = project
+  .in(file("play23-common"))
+  .dependsOn(scalaCommon)
 
 lazy val play23ConductRBundleLib = project
   .in(file("play23-conductr-bundle-lib"))
   .dependsOn(akka23ConductRBundleLib)
+  .dependsOn(play23Common)
   .dependsOn(testLib % "test->compile")
+
+lazy val play23ConductRClientLib = project
+  .in(file("play23-conductr-client-lib"))
+  .dependsOn(scalaConductRClientLib)
+  .dependsOn(play23Common)
+  .dependsOn(testLib % "test->compile")
+
+
+// Play 2.4
+lazy val play24Common = project
+  .in(file("play24-common"))
+  .dependsOn(scalaCommon)
 
 lazy val play24ConductRBundleLib = project
   .in(file("play24-conductr-bundle-lib"))
   .dependsOn(akka23ConductRBundleLib)
+  .dependsOn(play24Common)
   .dependsOn(testLib % "test->compile")
 
+lazy val play24ConductRClientLib = project
+  .in(file("play24-conductr-client-lib"))
+  .dependsOn(scalaConductRClientLib)
+  .dependsOn(play24Common)
+  .dependsOn(testLib % "test->compile")
+
+
+// Test library
 lazy val testLib = project
   .in(file("test-lib"))
   

--- a/common/build.sbt
+++ b/common/build.sbt
@@ -1,0 +1,9 @@
+name := "conductr-lib-common"
+
+javacOptions in compile ++= List("-encoding", "UTF-8", "-source", "1.6", "-target", "1.6", "-Xlint:unchecked", "-Xlint:deprecation")
+javacOptions in doc ++= List("-encoding", "UTF-8", "-source", "1.6")
+
+unmanagedSourceDirectories in Compile := List((javaSource in Compile).value)
+
+autoScalaLibrary := false
+crossPaths := false

--- a/common/src/main/java/com/typesafe/conductr/HttpPayload.java
+++ b/common/src/main/java/com/typesafe/conductr/HttpPayload.java
@@ -1,4 +1,4 @@
-package com.typesafe.conductr.bundlelib;
+package com.typesafe.conductr;
 
 import java.net.URL;
 
@@ -16,7 +16,7 @@ public class HttpPayload {
         "GET", "POST", "HEAD", "OPTIONS", "PUT", "DELETE", "TRACE"
     };
 
-    HttpPayload(URL url, String requestMethod, boolean followRedirects) {
+    public HttpPayload(URL url, String requestMethod, boolean followRedirects) {
         String rm = requestMethod.toUpperCase();
         boolean validMethod = false;
         for (String vm: requestMethods) {
@@ -32,11 +32,11 @@ public class HttpPayload {
         this.followRedirects = followRedirects;
     }
 
-    HttpPayload(URL url, String requestMethod) {
+    public HttpPayload(URL url, String requestMethod) {
         this(url, requestMethod, false);
     }
 
-    HttpPayload(URL url) {
+    public HttpPayload(URL url) {
         this(url, "GET", false);
     }
 

--- a/common/src/test/scala/com.typesafe.conductr/HttpPayloadSpec.scala
+++ b/common/src/test/scala/com.typesafe.conductr/HttpPayloadSpec.scala
@@ -1,8 +1,6 @@
-package com.typesafe.conductr.bundlelib
+package com.typesafe.conductr
 
 import java.net.URL
-
-import com.typesafe.conductr.UnitTest
 
 class HttpPayloadSpec extends UnitTest {
   "An HttpPayload" should {

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/LocationService.java
@@ -2,6 +2,7 @@ package com.typesafe.conductr.bundlelib;
 
 import java.net.MalformedURLException;
 import java.net.URL;
+import com.typesafe.conductr.HttpPayload;
 import static com.typesafe.conductr.bundlelib.Env.*;
 
 /**

--- a/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
+++ b/conductr-bundle-lib/src/main/java/com/typesafe/conductr/bundlelib/StatusService.java
@@ -2,6 +2,7 @@ package com.typesafe.conductr.bundlelib;
 
 import java.io.IOException;
 import java.net.URL;
+import com.typesafe.conductr.HttpPayload;
 import static com.typesafe.conductr.bundlelib.Env.*;
 
 /**

--- a/play23-common/build.sbt
+++ b/play23-common/build.sbt
@@ -1,0 +1,7 @@
+name := "play23-common-conductr-lib"
+
+libraryDependencies ++= List(
+  Library.play23Ws
+)
+
+resolvers += Resolvers.playTypesafeReleases

--- a/play23-common/src/main/scala/com/typesafe/conductr/play/ConnectionHandler.scala
+++ b/play23-common/src/main/scala/com/typesafe/conductr/play/ConnectionHandler.scala
@@ -1,8 +1,8 @@
-package com.typesafe.conductr.bundlelib.play
+package com.typesafe.conductr.play
 
 import com.ning.http.client.AsyncHttpClientConfig
-import com.typesafe.conductr.bundlelib.HttpPayload
-import com.typesafe.conductr.bundlelib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import com.typesafe.conductr.HttpPayload
+import com.typesafe.conductr.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
 import play.api.libs.ws.ning.{ NingWSClient, NingAsyncHttpClientConfigBuilder }
 import play.api.libs.ws.{ DefaultWSClientConfig, WSClient }
 import play.api.libs.concurrent.Execution.{ Implicits => PlayImplicits }
@@ -48,7 +48,7 @@ class ConnectionContext(val wsClient: WSClient)(implicit val executionContext: E
  * INTERNAL API
  * Handles the Play.WS requests and responses
  */
-private[bundlelib] class ConnectionHandler extends AbstractConnectionHandler {
+class ConnectionHandler extends AbstractConnectionHandler {
 
   override protected type CC = ConnectionContext
 

--- a/play23-conductr-bundle-lib/build.sbt
+++ b/play23-conductr-bundle-lib/build.sbt
@@ -3,7 +3,6 @@ import Tests._
 name := "play23-conductr-bundle-lib"
 
 libraryDependencies ++= List(
-  Library.play23Ws,
   Library.akka23Testkit % "test",
   Library.play23Test    % "test",
   Library.scalaTest     % "test"

--- a/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
+++ b/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.play
 
 import java.net.URI
-
+import com.typesafe.conductr.play.{ ConnectionContext, ConnectionHandler }
 import com.typesafe.conductr.bundlelib.scala.{ CacheLike, AbstractLocationService }
 import play.api.libs.concurrent.Execution.Implicits
 import play.libs.F

--- a/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
+++ b/play23-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.play
 
 import com.typesafe.conductr.bundlelib.scala.AbstractStatusService
-
+import com.typesafe.conductr.play.{ ConnectionContext, ConnectionHandler }
 import play.api.libs.concurrent.Execution.Implicits
 import play.libs.F
 

--- a/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
+++ b/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
@@ -2,6 +2,7 @@ package com.typesafe.conductr.bundlelib.play;
 
 import akka.util.Timeout;
 import com.typesafe.conductr.bundlelib.scala.LocationCache;
+import com.typesafe.conductr.play.ConnectionContext;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import play.libs.F;

--- a/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
+++ b/play23-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
@@ -8,6 +8,7 @@ import play.libs.F;
 import play.libs.HttpExecution;
 import play.test.Helpers;
 import scala.concurrent.duration.Duration;
+import com.typesafe.conductr.play.ConnectionContext;
 
 import static org.junit.Assert.assertEquals;
 

--- a/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -9,7 +9,7 @@ import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
+import com.typesafe.conductr.play.ConnectionContext.Implicits
 import com.typesafe.conductr.bundlelib.scala.{ URL, URI, LocationCache }
 import com.typesafe.conductr.AkkaUnitTest
 

--- a/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
+++ b/play23-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
@@ -7,11 +7,11 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
+import com.typesafe.conductr.play.ConnectionContext.Implicits
 import com.typesafe.conductr.{ AkkaUnitTest, _ }
 
-import scala.concurrent.Await
-import scala.util.{ Failure, Success }
+import _root_.scala.concurrent.Await
+import _root_.scala.util.{ Failure, Success }
 
 class StatusServiceSpecWithEnv extends AkkaUnitTest("StatusServiceSpecWithEnv", "akka.loglevel = INFO") {
 

--- a/play23-conductr-client-lib/build.sbt
+++ b/play23-conductr-client-lib/build.sbt
@@ -1,0 +1,1 @@
+name := "play23-conductr-client-lib"

--- a/play24-common/build.sbt
+++ b/play24-common/build.sbt
@@ -1,0 +1,5 @@
+name := "play24-common-conductr-lib"
+
+libraryDependencies ++= List(
+  Library.play24Ws
+)

--- a/play24-common/src/main/scala/com/typesafe/conductr/play/ConnectionHandler.scala
+++ b/play24-common/src/main/scala/com/typesafe/conductr/play/ConnectionHandler.scala
@@ -1,8 +1,8 @@
-package com.typesafe.conductr.bundlelib.play
+package com.typesafe.conductr.play
 
 import com.ning.http.client.AsyncHttpClientConfig
-import com.typesafe.conductr.bundlelib.HttpPayload
-import com.typesafe.conductr.bundlelib.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import com.typesafe.conductr.HttpPayload
+import com.typesafe.conductr.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
 import play.api.libs.ws.ning.{ NingWSClientConfig, NingWSClient, NingAsyncHttpClientConfigBuilder }
 import play.api.libs.ws.WSClient
 import play.api.libs.concurrent.Execution.{ Implicits => PlayImplicits }
@@ -48,7 +48,7 @@ class ConnectionContext(val wsClient: WSClient)(implicit val executionContext: E
  * INTERNAL API
  * Handles the Play.WS requests and responses
  */
-private[bundlelib] class ConnectionHandler extends AbstractConnectionHandler {
+class ConnectionHandler extends AbstractConnectionHandler {
 
   override protected type CC = ConnectionContext
 

--- a/play24-conductr-bundle-lib/build.sbt
+++ b/play24-conductr-bundle-lib/build.sbt
@@ -3,7 +3,6 @@ import Tests._
 name := "play24-conductr-bundle-lib"
 
 libraryDependencies ++= List(
-  Library.play24Ws,
   Library.akka23Testkit % "test",
   Library.play24Test    % "test",
   Library.scalaTest     % "test"

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRLifecycle.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/ConductRLifecycle.scala
@@ -1,6 +1,6 @@
 package com.typesafe.conductr.bundlelib.play
 
-import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
+import com.typesafe.conductr.play.ConnectionContext.Implicits
 import play.api.inject.{ Binding, Module }
 import play.api.{ Environment, Configuration, Logger }
 import javax.inject.Singleton

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/LocationService.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.play
 
 import java.net.URI
-
+import com.typesafe.conductr.play.{ ConnectionHandler, ConnectionContext }
 import com.typesafe.conductr.bundlelib.scala.{ CacheLike, AbstractLocationService }
 import play.api.libs.concurrent.Execution.Implicits
 import play.libs.F

--- a/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
+++ b/play24-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/play/StatusService.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.play
 
 import com.typesafe.conductr.bundlelib.scala.AbstractStatusService
-
+import com.typesafe.conductr.play.{ ConnectionHandler, ConnectionContext }
 import play.api.libs.concurrent.Execution.Implicits
 import play.libs.F
 

--- a/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
+++ b/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/LocationServiceTest.java
@@ -2,6 +2,7 @@ package com.typesafe.conductr.bundlelib.play;
 
 import akka.util.Timeout;
 import com.typesafe.conductr.bundlelib.scala.LocationCache;
+import com.typesafe.conductr.play.ConnectionContext;
 import org.junit.Test;
 import org.scalatest.junit.JUnitSuite;
 import play.libs.F;

--- a/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
+++ b/play24-conductr-bundle-lib/src/test/java/com/typesafe/conductr/bundlelib/play/StatusServiceTest.java
@@ -8,6 +8,7 @@ import play.libs.F;
 import play.libs.HttpExecution;
 import play.test.Helpers;
 import scala.concurrent.duration.Duration;
+import com.typesafe.conductr.play.ConnectionContext;
 
 import static org.junit.Assert.assertEquals;
 

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/LocationServiceSpecWithEnv.scala
@@ -9,12 +9,12 @@ import akka.http.scaladsl.model.{ HttpEntity, HttpResponse, StatusCodes }
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
+import com.typesafe.conductr.play.ConnectionContext.Implicits
 import com.typesafe.conductr.bundlelib.scala.{ URL, URI, LocationCache }
 import com.typesafe.conductr.{ AkkaUnitTest, _ }
 
-import scala.concurrent.Await
-import scala.util.{ Failure, Success }
+import _root_.scala.concurrent.Await
+import _root_.scala.util.{ Failure, Success }
 
 class LocationServiceSpecWithEnv extends AkkaUnitTest("LocationServiceSpecWithEnv", "akka.loglevel = INFO") {
 

--- a/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
+++ b/play24-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/play/StatusServiceSpecWithEnv.scala
@@ -7,11 +7,11 @@ import akka.http.scaladsl.model.StatusCodes
 import akka.http.scaladsl.server.Directives._
 import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
-import com.typesafe.conductr.bundlelib.play.ConnectionContext.Implicits
+import com.typesafe.conductr.play.ConnectionContext.Implicits
 import com.typesafe.conductr.{ AkkaUnitTest, _ }
 
-import scala.concurrent.Await
-import scala.util.{ Failure, Success }
+import _root_.scala.concurrent.Await
+import _root_.scala.util.{ Failure, Success }
 
 class StatusServiceSpecWithEnv extends AkkaUnitTest("StatusServiceSpecWithEnv", "akka.loglevel = INFO") {
 

--- a/play24-conductr-client-lib/build.sbt
+++ b/play24-conductr-client-lib/build.sbt
@@ -1,0 +1,1 @@
+name := "play24-conductr-client-lib"

--- a/scala-common/build.sbt
+++ b/scala-common/build.sbt
@@ -1,0 +1,1 @@
+name := "scala-common-conductr-lib"

--- a/scala-common/src/main/scala/com/typesafe/conductr/scala/AbstractConnectionHandler.scala
+++ b/scala-common/src/main/scala/com/typesafe/conductr/scala/AbstractConnectionHandler.scala
@@ -1,7 +1,6 @@
-package com.typesafe.conductr.bundlelib.scala
+package com.typesafe.conductr.scala
 
-import com.typesafe.conductr.bundlelib.HttpPayload
-
+import com.typesafe.conductr.HttpPayload
 import scala.concurrent.Future
 
 /**
@@ -15,7 +14,7 @@ abstract class AbstractConnectionContext
  * Connection handlers provide the means to establish a connection, issue a request and then finalize
  * the connection
  */
-private[bundlelib] abstract class AbstractConnectionHandler {
+abstract class AbstractConnectionHandler {
 
   protected final val UserAgent = "TypesafeConductRBundleLib"
 

--- a/scala-common/src/main/scala/com/typesafe/conductr/scala/ConnectionHandler.scala
+++ b/scala-common/src/main/scala/com/typesafe/conductr/scala/ConnectionHandler.scala
@@ -1,10 +1,8 @@
-package com.typesafe.conductr.bundlelib.scala
+package com.typesafe.conductr.scala
 
 import java.io.IOException
 import java.net.HttpURLConnection
-
-import com.typesafe.conductr.bundlelib.HttpPayload
-
+import com.typesafe.conductr.HttpPayload
 import scala.concurrent._
 import scala.util.{ Failure, Success, Try }
 
@@ -32,7 +30,7 @@ class ConnectionContext()(implicit val executionContext: ExecutionContext) exten
  * INTERNAL API
  * Handles the JDK HttpURLConnection requests and responses
  */
-private[bundlelib] class ConnectionHandler extends AbstractConnectionHandler {
+class ConnectionHandler extends AbstractConnectionHandler {
 
   override protected type CC = ConnectionContext
 

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/AbstractLocationService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/AbstractLocationService.scala
@@ -4,7 +4,9 @@ import java.io.IOException
 import java.net.{ URL => JavaURL, URI => JavaURI }
 import java.util.concurrent.TimeUnit
 
-import com.typesafe.conductr.bundlelib.{ HttpPayload, LocationService => JavaLocationService }
+import com.typesafe.conductr.HttpPayload
+import com.typesafe.conductr.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import com.typesafe.conductr.bundlelib.{ LocationService => JavaLocationService }
 
 import scala.concurrent._
 import scala.concurrent.duration._

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/AbstractStatusService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/AbstractStatusService.scala
@@ -2,7 +2,9 @@ package com.typesafe.conductr.bundlelib.scala
 
 import java.io.IOException
 
-import com.typesafe.conductr.bundlelib.{ StatusService => JavaStatusService, HttpPayload }
+import com.typesafe.conductr.HttpPayload
+import com.typesafe.conductr.scala.{ AbstractConnectionHandler, AbstractConnectionContext }
+import com.typesafe.conductr.bundlelib.{ StatusService => JavaStatusService }
 
 import scala.concurrent.Future
 

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/LocationService.scala
@@ -2,6 +2,8 @@ package com.typesafe.conductr.bundlelib.scala
 
 import java.net.{ URI => JavaURI }
 
+import com.typesafe.conductr.scala.{ ConnectionContext, ConnectionHandler }
+
 import scala.concurrent.Future
 
 object LocationService extends LocationService(new ConnectionHandler)

--- a/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/StatusService.scala
+++ b/scala-conductr-bundle-lib/src/main/scala/com/typesafe/conductr/bundlelib/scala/StatusService.scala
@@ -1,5 +1,7 @@
 package com.typesafe.conductr.bundlelib.scala
 
+import com.typesafe.conductr.scala.{ ConnectionHandler, ConnectionContext }
+
 import scala.concurrent.Future
 
 object StatusService extends StatusService(new ConnectionHandler)

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpec.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.scala
 
 import com.typesafe.conductr.AkkaUnitTest
-import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits
+import com.typesafe.conductr.scala.ConnectionContext.Implicits
 import scala.concurrent.Await
 
 class LocationServiceSpec extends AkkaUnitTest {

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/LocationServiceSpecWithEnv.scala
@@ -9,7 +9,7 @@ import akka.testkit.TestProbe
 import com.typesafe.conductr.AkkaUnitTest
 import java.net.InetSocketAddress
 
-import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits
+import com.typesafe.conductr.scala.ConnectionContext.Implicits
 
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpec.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpec.scala
@@ -1,7 +1,7 @@
 package com.typesafe.conductr.bundlelib.scala
 
 import com.typesafe.conductr.AkkaUnitTest
-import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits
+import com.typesafe.conductr.scala.ConnectionContext.Implicits
 import scala.concurrent.Await
 
 class StatusServiceSpec extends AkkaUnitTest("StatusServiceSpec", "akka.loglevel = INFO") {

--- a/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpecWithEnv.scala
+++ b/scala-conductr-bundle-lib/src/test/scala/com/typesafe/conductr/bundlelib/scala/StatusServiceSpecWithEnv.scala
@@ -7,7 +7,7 @@ import akka.stream.ActorMaterializer
 import akka.testkit.TestProbe
 import com.typesafe.conductr.AkkaUnitTest
 import java.net.InetSocketAddress
-import com.typesafe.conductr.bundlelib.scala.ConnectionContext.Implicits
+import com.typesafe.conductr.scala.ConnectionContext.Implicits
 
 import scala.concurrent.Await
 import scala.util.{ Failure, Success }

--- a/scala-conductr-client-lib/build.sbt
+++ b/scala-conductr-client-lib/build.sbt
@@ -1,0 +1,9 @@
+name := "scala-conductr-client-lib"
+
+libraryDependencies ++= List(
+  Library.akka23HttpTestkit % "test",
+  Library.akka23Testkit     % "test",
+  Library.scalaTest         % "test"
+)
+
+fork in Test := true


### PR DESCRIPTION
The `conductr-bundle-lib` project has been splitted up into these modules. Later we will rename the project to `conductr-lib`:
- common
  - scala-common
    - akka23-common
    - play23-common
    - play24-common
- conductr-bundle-lib
  - scala-conductr-bundle-lib
    - akka23-conductr-bundle-lib
    - play23-conductr-bundle-lib
    - play24-conductr-bundle-lib
- scala-conductr-client-lib
  - akka23-conductr-client-lib
  - play23-conductr-client-lib
  - play24-conductr-client-lib

The common modules containing classes which are shared across `conductr-bundle-lib` and `conductr-client-lib`.